### PR TITLE
Optimise term docs iterator

### DIFF
--- a/src/search/index/reader.rs
+++ b/src/search/index/reader.rs
@@ -7,7 +7,7 @@ pub trait IndexReader<'a> {
 
     fn num_docs(&self) -> usize;
     fn iter_docids_all(&'a self) -> Self::AllDocRefIterator;
-    fn iter_docids_with_term(&'a self, term: Term, field_name: String) -> Self::TermDocRefIterator;
+    fn iter_docids_with_term(&'a self, term: &Term, field_name: &str) -> Self::TermDocRefIterator;
     fn iter_terms(&'a self) -> Box<Iterator<Item=&'a Term> + 'a>;
     //pub fn retrieve_document(&self, &Self::DocRef) -> Document;
 }

--- a/src/search/index/reader.rs
+++ b/src/search/index/reader.rs
@@ -7,7 +7,7 @@ pub trait IndexReader<'a> {
 
     fn num_docs(&self) -> usize;
     fn iter_docids_all(&'a self) -> Self::AllDocRefIterator;
-    fn iter_docids_with_term(&'a self, term: &Term, field_name: &str) -> Self::TermDocRefIterator;
+    fn iter_docids_with_term(&'a self, term: &Term, field_name: &str) -> Option<Self::TermDocRefIterator>;
     fn iter_terms(&'a self) -> Box<Iterator<Item=&'a Term> + 'a>;
     //pub fn retrieve_document(&self, &Self::DocRef) -> Document;
 }

--- a/src/search/index/store/memory.rs
+++ b/src/search/index/store/memory.rs
@@ -130,20 +130,20 @@ impl<'a> IndexReader<'a> for MemoryIndexStore {
         }
     }
 
-    fn iter_docids_with_term(&'a self, term: &Term, field_name: &str) -> MemoryIndexStoreTermDocRefIterator<'a> {
+    fn iter_docids_with_term(&'a self, term: &Term, field_name: &str) -> Option<MemoryIndexStoreTermDocRefIterator<'a>> {
         let fields = match self.index.get(term) {
             Some(fields) => fields,
-            None => panic!("FOO"),
+            None => return None,
         };
 
         let docs = match fields.get(field_name) {
             Some(docs) => docs,
-            None => panic!("FOO"),
+            None => return None,
         };
 
-        MemoryIndexStoreTermDocRefIterator {
+        Some(MemoryIndexStoreTermDocRefIterator {
             iterator: docs.iter(),
-        }
+        })
     }
 
     fn iter_terms(&'a self) -> Box<Iterator<Item=&'a Term> + 'a> {
@@ -235,6 +235,6 @@ mod tests {
     fn test_term_docs_iterator() {
         let store = make_test_store();
 
-        assert_eq!(store.iter_docids_with_term(&Term::String("hello".to_string()), "title").count(), 1);
+        assert_eq!(store.iter_docids_with_term(&Term::String("hello".to_string()), "title").unwrap().count(), 1);
     }
 }

--- a/src/search/query_set.rs
+++ b/src/search/query_set.rs
@@ -228,7 +228,7 @@ pub fn build_iterator_from_query<'a, T: IndexReader<'a>>(reader: &'a T, query: &
             match *matcher {
                 TermMatcher::Exact => {
                     QuerySetIterator::Term {
-                        iter: reader.iter_docids_with_term(term.clone(), field.clone()),
+                        iter: reader.iter_docids_with_term(term, field),
                     }
                 }
                 TermMatcher::Prefix => {
@@ -252,7 +252,7 @@ pub fn build_iterator_from_query<'a, T: IndexReader<'a>>(reader: &'a T, query: &
                         0 => QuerySetIterator::None,
                         1 => {
                             QuerySetIterator::Term {
-                                iter: reader.iter_docids_with_term(terms[0].clone(), field.clone()),
+                                iter: reader.iter_docids_with_term(&terms[0], field),
                             }
                         }
                         _ => {
@@ -260,7 +260,7 @@ pub fn build_iterator_from_query<'a, T: IndexReader<'a>>(reader: &'a T, query: &
                             let mut iters = VecDeque::new();
                             for term in terms.iter() {
                                 iters.push_back(QuerySetIterator::Term {
-                                    iter: reader.iter_docids_with_term(term.clone(), field.clone()),
+                                    iter: reader.iter_docids_with_term(term, field),
                                 });
                             }
 
@@ -389,10 +389,11 @@ mod benches {
     #[bench]
     fn bench_fizz_term(b: &mut Bencher) {
         let store = make_test_store();
+        let fizz_term = Term::String("fizz".to_string());
 
         b.iter(|| {
             let mut iterator: QuerySetIterator<MemoryIndexStore> = QuerySetIterator::Term {
-                iter: store.iter_docids_with_term(Term::String("fizz".to_string()), "body".to_string()),
+                iter: store.iter_docids_with_term(&fizz_term, "body"),
             };
 
             for doc_id in iterator {}
@@ -403,10 +404,11 @@ mod benches {
     #[bench]
     fn bench_buzz_term(b: &mut Bencher) {
         let store = make_test_store();
+        let buzz_term = Term::String("buzz".to_string());
 
         b.iter(|| {
             let mut iterator: QuerySetIterator<MemoryIndexStore> = QuerySetIterator::Term {
-                iter: store.iter_docids_with_term(Term::String("buzz".to_string()), "body".to_string()),
+                iter: store.iter_docids_with_term(&buzz_term, "body"),
             };
 
             for doc_id in iterator {}
@@ -417,13 +419,15 @@ mod benches {
     #[bench]
     fn bench_fizzbuzz_conjunction(b: &mut Bencher) {
         let store = make_test_store();
+        let fizz_term = Term::String("fizz".to_string());
+        let buzz_term = Term::String("buzz".to_string());
 
         b.iter(|| {
             let mut fizz_iterator: QuerySetIterator<MemoryIndexStore> = QuerySetIterator::Term {
-                iter: store.iter_docids_with_term(Term::String("fizz".to_string()), "body".to_string()),
+                iter: store.iter_docids_with_term(&fizz_term, "body"),
             };
             let mut buzz_iterator: QuerySetIterator<MemoryIndexStore> = QuerySetIterator::Term {
-                iter: store.iter_docids_with_term(Term::String("buzz".to_string()), "body".to_string()),
+                iter: store.iter_docids_with_term(&buzz_term, "body"),
             };
             let mut iterator: QuerySetIterator<MemoryIndexStore> = QuerySetIterator::Conjunction {
                 iter_a: Box::new(fizz_iterator),
@@ -441,13 +445,15 @@ mod benches {
     #[bench]
     fn bench_fizzbuzz_disjunction(b: &mut Bencher) {
         let store = make_test_store();
+        let fizz_term = Term::String("fizz".to_string());
+        let buzz_term = Term::String("buzz".to_string());
 
         b.iter(|| {
             let mut fizz_iterator: QuerySetIterator<MemoryIndexStore> = QuerySetIterator::Term {
-                iter: store.iter_docids_with_term(Term::String("fizz".to_string()), "body".to_string()),
+                iter: store.iter_docids_with_term(&fizz_term, "body"),
             };
             let mut buzz_iterator: QuerySetIterator<MemoryIndexStore> = QuerySetIterator::Term {
-                iter: store.iter_docids_with_term(Term::String("buzz".to_string()), "body".to_string()),
+                iter: store.iter_docids_with_term(&buzz_term, "body"),
             };
             let mut iterator: QuerySetIterator<MemoryIndexStore> = QuerySetIterator::Disjunction {
                 iter_a: Box::new(fizz_iterator),
@@ -465,13 +471,15 @@ mod benches {
     #[bench]
     fn bench_fizzbuzz_exclusion(b: &mut Bencher) {
         let store = make_test_store();
+        let fizz_term = Term::String("fizz".to_string());
+        let buzz_term = Term::String("buzz".to_string());
 
         b.iter(|| {
             let mut fizz_iterator: QuerySetIterator<MemoryIndexStore> = QuerySetIterator::Term {
-                iter: store.iter_docids_with_term(Term::String("fizz".to_string()), "body".to_string()),
+                iter: store.iter_docids_with_term(&fizz_term, "body"),
             };
             let mut buzz_iterator: QuerySetIterator<MemoryIndexStore> = QuerySetIterator::Term {
-                iter: store.iter_docids_with_term(Term::String("buzz".to_string()), "body".to_string()),
+                iter: store.iter_docids_with_term(&buzz_term, "body"),
             };
             let mut iterator: QuerySetIterator<MemoryIndexStore> = QuerySetIterator::Exclusion {
                 iter_a: Box::new(fizz_iterator),


### PR DESCRIPTION
Was previously calling a slow next_doc method on each iteration. Now uses an iterator which gives massive performance improvements (500-770x speed increase!).

```
 name                                                    old ns/iter  new ns/iter  diff ns/iter   diff % 
 search::query_set::benches::bench_all                   113,670      118,289             4,619    4.06% 
 search::query_set::benches::bench_buzz_term             12,460,039   26,974        -12,433,065  -99.78% 
 search::query_set::benches::bench_fizz_term             34,493,952   44,738        -34,449,214  -99.87% 
 search::query_set::benches::bench_fizzbuzz_conjunction  46,930,663   89,786        -46,840,877  -99.81% 
 search::query_set::benches::bench_fizzbuzz_disjunction  46,987,618   124,635       -46,862,983  -99.73% 
 search::query_set::benches::bench_fizzbuzz_exclusion    46,974,383   107,404       -46,866,979  -99.77%
```

TODO:
- [x] Some error management code needs cleaning up
