### PR TITLE
Added new method of boosting queries

### DIFF
--- a/abra/src/query/mod.rs
+++ b/abra/src/query/mod.rs
@@ -41,10 +41,6 @@ pub enum Query {
         query: Box<Query>,
         exclude: Box<Query>
     },
-    Boost {
-        query: Box<Query>,
-        boost: f64,
-    },
 }
 
 
@@ -152,21 +148,6 @@ impl Query {
             Query::Exclude{ref mut query, ref exclude} => {
                 query.boost(add_boost);
             }
-            Query::Boost{ref query, ref mut boost} => {
-                *boost *= add_boost;
-            }
-        }
-    }
-
-    pub fn new_boost(query: Query, boost: f64) -> Query {
-        if boost == 1.0f64 {
-            // This boost query won't have any effect
-            return query;
-        }
-
-        Query::Boost {
-            query: Box::new(query),
-            boost: boost,
         }
     }
 
@@ -232,9 +213,6 @@ impl Query {
             }
             Query::Exclude{ref query, ref exclude} => {
                 query.matches(doc) && !exclude.matches(doc)
-            }
-            Query::Boost{ref query, boost} => {
-                query.matches(doc)
             }
         }
     }
@@ -341,21 +319,6 @@ impl Query {
                     query.rank(index_reader, doc)
                 } else {
                     None
-                }
-            }
-            Query::Boost{ref query, boost} => {
-                if boost == 0.0f64 {
-                    // Score of inner query isn't needed
-                    if query.matches(doc) {
-                        Some(0.0f64)
-                    } else {
-                        None
-                    }
-                } else {
-                    match query.rank(index_reader, doc) {
-                        Some(score) => Some(score * boost),
-                        None => None
-                    }
                 }
             }
         }

--- a/abra/src/query/term_scorer.rs
+++ b/abra/src/query/term_scorer.rs
@@ -6,6 +6,7 @@ use store::IndexReader;
 #[derive(Debug, PartialEq)]
 pub struct TermScorer {
     similarity_model: SimilarityModel,
+    pub boost: f64,
 }
 
 
@@ -18,16 +19,21 @@ impl TermScorer {
 
         self.similarity_model.score(term_frequency, length, total_tokens, total_docs, total_docs_with_term)
     }
-}
 
-
-impl Default for TermScorer {
-    fn default() -> TermScorer {
+    pub fn default_with_boost(boost: f64) -> TermScorer {
         TermScorer {
             similarity_model: SimilarityModel::BM25 {
                 k1: 1.2,
                 b: 0.75,
             },
+            boost: boost,
         }
+    }
+}
+
+
+impl Default for TermScorer {
+    fn default() -> TermScorer {
+        TermScorer::default_with_boost(1.0f64)
     }
 }

--- a/abra/src/query_set.rs
+++ b/abra/src/query_set.rs
@@ -348,8 +348,5 @@ pub fn build_iterator_from_query<'a, T: IndexReader<'a>>(reader: &'a T, query: &
                 current_doc_b: None,
             }
         }
-        Query::Boost{ref query, boost} => {
-            build_iterator_from_query(reader, query)
-        }
     }
 }

--- a/abra/src/query_set.rs
+++ b/abra/src/query_set.rs
@@ -216,7 +216,7 @@ fn build_disjunction_iterator<'a, T: IndexReader<'a>>(mut iters: VecDeque<QueryS
 
 pub fn build_iterator_from_query<'a, T: IndexReader<'a>>(reader: &'a T, query: &Query) -> QuerySetIterator<'a, T> {
     match *query {
-        Query::MatchAll => {
+        Query::MatchAll{score} => {
             QuerySetIterator::All {
                 iter: reader.iter_docids_all(),
             }

--- a/src/query_parser/filtered_query.rs
+++ b/src/query_parser/filtered_query.rs
@@ -10,7 +10,7 @@ use query_parser::{parse as parse_query};
 pub fn parse(context: &QueryParseContext, json: &Json) -> Result<Query, QueryParseError> {
     let object = try!(json.as_object().ok_or(QueryParseError::ExpectedObject));
 
-    let mut query = Query::MatchAll;
+    let mut query = Query::new_match_all();
 
     let mut filter = Query::MatchNone;
     let mut has_filter_key = false;
@@ -95,7 +95,7 @@ mod tests {
         ").unwrap());
 
         assert_eq!(query, Ok(Query::Filter {
-            query: Box::new(Query::MatchAll),
+            query: Box::new(Query::new_match_all()),
             filter: Box::new(Query::MatchTerm {
                 field: "the".to_string(),
                 term: Term::String("filter".to_string()),

--- a/src/query_parser/match_all_query.rs
+++ b/src/query_parser/match_all_query.rs
@@ -26,7 +26,7 @@ pub fn parse(context: &QueryParseContext, json: &Json) -> Result<Query, QueryPar
     let mut query = Query::new_match_all();
 
     // Add boost
-    query = Query::new_boost(query, boost);
+    query.boost(boost);
 
     return Ok(query);
 }
@@ -49,7 +49,7 @@ mod tests {
         }
         ").unwrap());
 
-        assert_eq!(query, Ok(Query::new_match_all()))
+        assert_eq!(query, Ok(Query::MatchAll {score: 1.0f64}))
     }
 
     #[test]
@@ -60,10 +60,7 @@ mod tests {
         }
         ").unwrap());
 
-        assert_eq!(query, Ok(Query::Boost {
-            query: Box::new(Query::new_match_all()),
-            boost: 2.0f64,
-        }))
+        assert_eq!(query, Ok(Query::MatchAll {score: 2.0f64}))
     }
 
     #[test]
@@ -74,10 +71,7 @@ mod tests {
         }
         ").unwrap());
 
-        assert_eq!(query, Ok(Query::Boost {
-            query: Box::new(Query::new_match_all()),
-            boost: 2.0f64,
-        }))
+        assert_eq!(query, Ok(Query::MatchAll {score: 2.0f64}))
     }
 
     #[test]

--- a/src/query_parser/match_all_query.rs
+++ b/src/query_parser/match_all_query.rs
@@ -23,7 +23,7 @@ pub fn parse(context: &QueryParseContext, json: &Json) -> Result<Query, QueryPar
     }
 
 
-    let mut query = Query::MatchAll;
+    let mut query = Query::new_match_all();
 
     // Add boost
     query = Query::new_boost(query, boost);
@@ -49,7 +49,7 @@ mod tests {
         }
         ").unwrap());
 
-        assert_eq!(query, Ok(Query::MatchAll))
+        assert_eq!(query, Ok(Query::new_match_all()))
     }
 
     #[test]
@@ -61,7 +61,7 @@ mod tests {
         ").unwrap());
 
         assert_eq!(query, Ok(Query::Boost {
-            query: Box::new(Query::MatchAll),
+            query: Box::new(Query::new_match_all()),
             boost: 2.0f64,
         }))
     }
@@ -75,7 +75,7 @@ mod tests {
         ").unwrap());
 
         assert_eq!(query, Ok(Query::Boost {
-            query: Box::new(Query::MatchAll),
+            query: Box::new(Query::new_match_all()),
             boost: 2.0f64,
         }))
     }

--- a/src/query_parser/match_query.rs
+++ b/src/query_parser/match_query.rs
@@ -103,7 +103,7 @@ pub fn parse(context: &QueryParseContext, json: &Json) -> Result<Query, QueryPar
     };
 
     // Add boost
-    query = Query::new_boost(query, boost);
+    query.boost(boost);
 
     return Ok(query);
 }
@@ -202,14 +202,11 @@ mod tests {
         }
         ").unwrap());
 
-        assert_eq!(query, Ok(Query::Boost {
-            query: Box::new(Query::MatchTerm {
-                field: "foo".to_string(),
-                term: Term::String("bar".to_string()),
-                matcher: TermMatcher::Exact,
-                scorer: TermScorer::default(),
-            }),
-            boost: 2.0f64,
+        assert_eq!(query, Ok(Query::MatchTerm {
+            field: "foo".to_string(),
+            term: Term::String("bar".to_string()),
+            matcher: TermMatcher::Exact,
+            scorer: TermScorer::default_with_boost(2.0f64),
         }))
     }
 
@@ -224,14 +221,11 @@ mod tests {
         }
         ").unwrap());
 
-        assert_eq!(query, Ok(Query::Boost {
-            query: Box::new(Query::MatchTerm {
-                field: "foo".to_string(),
-                term: Term::String("bar".to_string()),
-                matcher: TermMatcher::Exact,
-                scorer: TermScorer::default(),
-            }),
-            boost: 2.0f64,
+        assert_eq!(query, Ok(Query::MatchTerm {
+            field: "foo".to_string(),
+            term: Term::String("bar".to_string()),
+            matcher: TermMatcher::Exact,
+            scorer: TermScorer::default_with_boost(2.0f64),
         }))
     }
 

--- a/src/query_parser/not_query.rs
+++ b/src/query_parser/not_query.rs
@@ -8,7 +8,7 @@ use query_parser::{QueryParseContext, QueryParseError, parse as parse_query};
 
 pub fn parse(context: &QueryParseContext, json: &Json) -> Result<Query, QueryParseError> {
     Ok(Query::Exclude {
-        query: Box::new(Query::MatchAll),
+        query: Box::new(Query::new_match_all()),
         exclude: Box::new(try!(parse_query(&context.clone().no_score(), json))),
     })
 }
@@ -35,7 +35,7 @@ mod tests {
         ").unwrap());
 
         assert_eq!(query, Ok(Query::Exclude {
-            query: Box::new(Query::MatchAll),
+            query: Box::new(Query::new_match_all()),
             exclude: Box::new(Query::MatchTerm {
                 field: "test".to_string(),
                 term: Term::String("foo".to_string()),

--- a/src/query_parser/prefix_query.rs
+++ b/src/query_parser/prefix_query.rs
@@ -54,7 +54,7 @@ pub fn parse(context: &QueryParseContext, json: &Json) -> Result<Query, QueryPar
                 };
 
                 // Add boost
-                query = Query::new_boost(query, boost);
+                query.boost(boost);
 
                 Ok(query)
             } else {
@@ -139,14 +139,11 @@ mod tests {
         }
         ").unwrap());
 
-        assert_eq!(query, Ok(Query::Boost {
-            query: Box::new(Query::MatchTerm {
-                field: "foo".to_string(),
-                term: Term::String("bar".to_string()),
-                matcher: TermMatcher::Prefix,
-                scorer: TermScorer::default(),
-            }),
-            boost: 2.0f64,
+        assert_eq!(query, Ok(Query::MatchTerm {
+            field: "foo".to_string(),
+            term: Term::String("bar".to_string()),
+            matcher: TermMatcher::Prefix,
+            scorer: TermScorer::default_with_boost(2.0f64),
         }));
     }
 
@@ -161,14 +158,11 @@ mod tests {
         }
         ").unwrap());
 
-        assert_eq!(query, Ok(Query::Boost {
-            query: Box::new(Query::MatchTerm {
-                field: "foo".to_string(),
-                term: Term::String("bar".to_string()),
-                matcher: TermMatcher::Prefix,
-                scorer: TermScorer::default(),
-            }),
-            boost: 2.0f64,
+        assert_eq!(query, Ok(Query::MatchTerm {
+            field: "foo".to_string(),
+            term: Term::String("bar".to_string()),
+            matcher: TermMatcher::Prefix,
+            scorer: TermScorer::default_with_boost(2.0f64),
         }));
     }
 

--- a/src/query_parser/term_query.rs
+++ b/src/query_parser/term_query.rs
@@ -53,7 +53,7 @@ pub fn parse(context: &QueryParseContext, json: &Json) -> Result<Query, QueryPar
             };
 
             // Add boost
-            query = Query::new_boost(query, boost);
+            query.boost(boost);
 
             Ok(query)
         }
@@ -135,14 +135,11 @@ mod tests {
         }
         ").unwrap());
 
-        assert_eq!(query, Ok(Query::Boost {
-            query: Box::new(Query::MatchTerm {
-                field: "foo".to_string(),
-                term: Term::String("bar".to_string()),
-                matcher: TermMatcher::Exact,
-                scorer: TermScorer::default(),
-            }),
-            boost: 2.0f64,
+        assert_eq!(query, Ok(Query::MatchTerm {
+            field: "foo".to_string(),
+            term: Term::String("bar".to_string()),
+            matcher: TermMatcher::Exact,
+            scorer: TermScorer::default_with_boost(2.0f64),
         }));
     }
 
@@ -157,14 +154,11 @@ mod tests {
         }
         ").unwrap());
 
-        assert_eq!(query, Ok(Query::Boost {
-            query: Box::new(Query::MatchTerm {
-                field: "foo".to_string(),
-                term: Term::String("bar".to_string()),
-                matcher: TermMatcher::Exact,
-                scorer: TermScorer::default(),
-            }),
-            boost: 2.0f64,
+        assert_eq!(query, Ok(Query::MatchTerm {
+            field: "foo".to_string(),
+            term: Term::String("bar".to_string()),
+            matcher: TermMatcher::Exact,
+            scorer: TermScorer::default_with_boost(2.0f64),
         }));
     }
 


### PR DESCRIPTION
Instead of a using separate "Boost" query type, this commit adds a new method that applies the boost directly to the leaf nodes of the query (which can either be MatchAll or MatchTerm). This has the same effect of using a Boost query but requires less space.
