### PR TITLE
Implement query builders

### DIFF
--- a/src/api/search_api.rs
+++ b/src/api/search_api.rs
@@ -37,7 +37,7 @@ pub fn view_count(req: &mut Request) -> IronResult<Response> {
             match query {
                 Ok(query) => {
                     let mut collector = TotalCountCollector::new();
-                    index_reader.search(&mut collector, &query).unwrap();
+                    index_reader.search(&mut collector, &query.build()).unwrap();
                     collector.get_total_count()
                 }
                 Err(_) => {
@@ -121,7 +121,7 @@ pub fn view_search(req: &mut Request) -> IronResult<Response> {
 
                     // Do the search
                     let mut collector = TopScoreCollector::new(from + size);
-                    index_reader.search(&mut collector, &query).unwrap();
+                    index_reader.search(&mut collector, &query.build()).unwrap();
 
                     // TODO: {"took":5,"timed_out":false,"_shards":{"total":5,"successful":5,"failed":0},"hits":{"total":4,"max_score":1.0,"hits":[{"_index":"wagtail","_type":"searchtests_searchtest_searchtests_searchtestchild","_id":"searchtests_searchtest:5380","_score":1.0,"fields":{"pk":["5380"]}},{"_index":"wagtail","_type":"searchtests_searchtest","_id":"searchtests_searchtest:5379","_score":1.0,"fields":{"pk":["5379"]}}]}}
                     Ok(json_response(status::Ok,

--- a/src/query_parser/and_query.rs
+++ b/src/query_parser/and_query.rs
@@ -3,18 +3,39 @@
 use rustc_serialize::json::Json;
 use kite::Query;
 
-use query_parser::{QueryParseContext, QueryParseError, parse as parse_query};
+use query_parser::{QueryParseContext, QueryParseError, QueryBuilder, parse as parse_query};
 
 
-pub fn parse(context: &QueryParseContext, json: &Json) -> Result<Query, QueryParseError> {
+#[derive(Debug)]
+struct AndQueryBuilder {
+    queries: Vec<Box<QueryBuilder>>,
+}
+
+
+impl QueryBuilder for AndQueryBuilder {
+    fn build(&self) -> Query {
+        let mut queries = Vec::new();
+
+        for query in self.queries.iter() {
+            queries.push(query.build());
+        }
+
+        Query::new_conjunction(queries)
+    }
+}
+
+
+pub fn parse(context: &QueryParseContext, json: &Json) -> Result<Box<QueryBuilder>, QueryParseError> {
     let filters = try!(json.as_array().ok_or(QueryParseError::ExpectedArray));
-    let mut sub_queries = Vec::new();
 
+    let mut queries = Vec::new();
     for filter in filters.iter() {
-        sub_queries.push(try!(parse_query(context, filter)));
+        queries.push(try!(parse_query(context, filter)));
     }
 
-    Ok(Query::new_conjunction(sub_queries))
+    Ok(Box::new(AndQueryBuilder {
+        queries: queries
+    }))
 }
 
 
@@ -43,7 +64,7 @@ mod tests {
                 }
             }
         ]
-        ").unwrap());
+        ").unwrap()).and_then(|builder| Ok(builder.build()));
 
         assert_eq!(query, Ok(Query::Conjunction {
             queries: vec![
@@ -68,7 +89,7 @@ mod tests {
         \"hello\"
         ").unwrap());
 
-        assert_eq!(query, Err(QueryParseError::ExpectedArray));
+        assert_eq!(query.err(), Some(QueryParseError::ExpectedArray));
 
         // Object
         let query = parse(&QueryParseContext::new(), &Json::from_str("
@@ -77,20 +98,20 @@ mod tests {
         }
         ").unwrap());
 
-        assert_eq!(query, Err(QueryParseError::ExpectedArray));
+        assert_eq!(query.err(), Some(QueryParseError::ExpectedArray));
 
         // Integer
         let query = parse(&QueryParseContext::new(), &Json::from_str("
         123
         ").unwrap());
 
-        assert_eq!(query, Err(QueryParseError::ExpectedArray));
+        assert_eq!(query.err(), Some(QueryParseError::ExpectedArray));
 
         // Float
         let query = parse(&QueryParseContext::new(), &Json::from_str("
         123.1234
         ").unwrap());
 
-        assert_eq!(query, Err(QueryParseError::ExpectedArray));
+        assert_eq!(query.err(), Some(QueryParseError::ExpectedArray));
     }
 }

--- a/src/query_parser/utils.rs
+++ b/src/query_parser/utils.rs
@@ -21,6 +21,7 @@ pub fn parse_float(json: &Json) -> Result<f64, QueryParseError> {
 }
 
 
+#[derive(Debug)]
 pub enum Operator {
     Or,
     And,


### PR DESCRIPTION
Query builders are an intermediate step between JSON and a runnable query.

I plan to make so `abra::Query` objects can only be created for a single index, which would mean we would have to parse the query once for every index/shard being searched. With this PR, queries will be parsed/validated once into a `QueryBuilder` and then that can quickly produce an `abra::Query` object for each index/shard.
